### PR TITLE
Release builds minimum supported from macOS 10.14.3 (Mojave) to macOS 10.15.2 (Catalina)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
       fail-fast: false
       matrix:
         # https://github.com/actions/virtual-environments#available-environments
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-10.15]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-11]
         qtltsver: ['5.15.2', '6.2.4'] # Qt LTS versions
         include:
           - os: macos-latest
             xcode: latest-stable
           # Target the same macOS setup as release workflow
-          - os: macos-10.15 
-            xcode: '10.3' # Supports macOS Mojave onwards
+          - os: macos-11 
+            xcode: '11.7' # Supports macOS 10.15.2 (Catalina) onwards
 
     steps:
     - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,12 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/virtual-environments#available-environments
-        os: [ubuntu-latest, windows-latest, macos-10.15] 
+        os: [ubuntu-latest, windows-latest, macos-11] 
         include:
           # Target oldest Xcode available, in oldest available macos runner, for widest OS support
           # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode
-          - os: macos-10.15 
-            xcode: '10.3' # Supports macOS Mojave onwards
+          - os: macos-11 
+            xcode: '11.7' # Supports macOS 10.15.2 (Catalina) onwards
 
     steps:
     - name: Checkout


### PR DESCRIPTION
macOS 10.15 deprecated by GitHub actions, move to macOS 11 and Xcode 11.7